### PR TITLE
feat: Add Cursor Rules

### DIFF
--- a/.cursor/rules/apply-license-header.mdc
+++ b/.cursor/rules/apply-license-header.mdc
@@ -1,0 +1,38 @@
+<!-->
+Copyright 2025 The OCI Artifact Maven Plugin Contributors
+
+SPDX-License-Identifier: Apache-2.0
+<-->
+---
+description: Apply License Headers
+globs:
+alwaysApply: true
+---
+
+When Cursor creates a new source file, it must add an appropriate license header to the file. The
+license header must be in the form of the comment at (or near) the first line of the file, using
+comment syntax that is appropriate for the source file's programming or markup language.
+
+The license header should have the copyright year and "The OCI Artifact Maven Plugin Contributors"
+as the copyright owner. The license is identified usig `SPDX-License-Identifier:`. The license for
+this project is `Apache-2.0`.
+
+For example, here is an appropriate header for a Java source file:
+
+```java
+/** 
+Copyright 2025 The OCI Artifact Maven Plugin Contributors
+
+SPDX-License-Identifier: Apache-2.0
+**/
+```
+
+And here is an appropriate header for an XML source file:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!-->
+Copyright 2025 The OCI Artifact Maven Plugin Contributors
+
+SPDX-License-Identifier: Apache-2.0
+<-->

--- a/.cursor/rules/run-integration-tests.mdc
+++ b/.cursor/rules/run-integration-tests.mdc
@@ -1,0 +1,16 @@
+<!-->
+Copyright 2025 The OCI Artifact Maven Plugin Contributors
+
+SPDX-License-Identifier: Apache-2.0
+<-->
+---
+description: Run Integration Tests for Java Changes
+globs: *.java,**/pom.xml
+alwaysApply: false
+---
+After Cursor changes one or more Java files in this project, run the following command
+to ensure the integration tests succeed:
+
+```sh
+mvn -Prun-its clean verify
+```


### PR DESCRIPTION
Adding cursor rules that ensure integration tests are run and license headers are applied. This will help contributors conform to project standards when utilizing Cursor or other AI-assisted IDEs.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body. 
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
