### PR TITLE
feat: Push OCI Artifacts with ORAS

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,4 +27,9 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
       maven4-enabled: false
-
+      # Disable integration tests
+      ff-goal: verify
+      verify-goal: verify
+      # Only run on JDK 17 and 21, and linux
+      jdk-matrix: '["17", "21"]'
+      os-matrix: '["ubuntu-latest"]'

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ A Maven plugin for deploying and resolving Maven artifacts from OCI container re
 
 **This originates as a hard fork of the [Apache Maven Deploy Plugin](https://maven.apache.org/plugins/maven-deploy-plugin/)**
 
+## Getting Started
+
+This plugin is not published on Maven Central (yet). To test it out, do the following:
+
+- Clone this repository
+- Build and install the plugin locally by running the following:
+
+```sh
+mvn clean install
+```
+
+Please note that this plugin is a very crude proof of concept, and may introduce siginificant
+and undocumented breaking changes in the future.
+
 ## Usage
 
 Add the following to your Maven project's `pom.xml`:
@@ -34,21 +48,92 @@ Add the following to your Maven project's `pom.xml`:
         <goals>
           <goal>deploy</goal>
         </goals>
+        <configuration>
+          <imageRepo>docker.io/myuser/myrepo</imageRepo>
+          <imageTag>${project.version}</imageTag>
+        </configuration>
       </execution>
     </executions>
   </plugin>
 </plugins>
 ```
 
+### Configuration Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `imageRepo` | String | Yes | - | Container image repository to push the artifacts to. Must be a fully qualified image reference (e.g., `docker.io/myuser/myrepo`) |
+| `imageTag` | String | No | `latest` | Container image tag to use when pushing the artifacts to the registry |
+| `registryUsername` | String | No | - | Username to use when pushing the artifacts to the registry |
+| `registryPassword` | String | No | - | Password to use when pushing the artifacts to the registry |
+| `insecureTLSNoVerify` | Boolean | No | `false` | Whether to skip TLS verification when pushing the artifacts to the registry |
+
+### Goals
+
+- `deploy`: Deploys all artifacts for a Maven project in an OCI artifact.
+- `deploy-file`: Deploys a specified file for a Maven project in an OCI artifact.
+
+### Authentication
+
+The plugin by default utilizes your system's local container runtime to authenticate to the target
+container registry. You can provide basic authentication data through the `registryUsername` and
+`registryPassword` configuration options.
+
+### Examples
+
+#### Basic Usage
+
+```xml
+<plugin>
+  <groupId>org.opencontainers.maven.plugins</groupId>
+  <artifactId>oci-artifact-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <goals>
+        <goal>deploy</goal>
+      </goals>
+      <configuration>
+        <imageRepo>ghcr.io/myorg/myproject</imageRepo>
+        <imageTag>${project.version}</imageTag>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
+#### With Custom Tag and Authentication
+
+```xml
+<plugin>
+  <groupId>org.opencontainers.maven.plugins</groupId>
+  <artifactId>oci-artifact-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <goals>
+        <goal>deploy</goal>
+      </goals>
+      <configuration>
+        <imageRepo>docker.io/myuser/myrepo</imageRepo>
+        <imageTag>custom-tag</imageTag>
+        <registryUsername>${env.REGISTRY_USERNAME}</registryUsername>
+        <registryPassword>${env.REGISTRY_PASSWORD}</registryPassword>
+      </configuration>
+    </execution>
+  </executions>
+</plugin>
+```
+
 ## Contributing to OCI Artifact Maven Plugin
 
 
+<!--
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)][license]
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.maven.plugins/maven-deploy-plugin.svg?label=Maven%20Central&versionPrefix=3.)](https://search.maven.org/artifact/org.apache.maven.plugins/maven-deploy-plugin)
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.maven.plugins/maven-deploy-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.maven.plugins/maven-deploy-plugin)
 [![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/maven/plugins/maven-deploy-plugin/README.md)
 [![Jenkins Status](https://img.shields.io/jenkins/s/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-deploy-plugin/job/master.svg?)][build]
 [![Jenkins tests](https://img.shields.io/jenkins/t/https/ci-maven.apache.org/job/Maven/job/maven-box/job/maven-deploy-plugin/job/master.svg?)][test-results]
+-->
 
 
 You have found a bug or you have an idea for a cool new feature? Contributing
@@ -78,7 +163,7 @@ There are some guidelines which will make applying PRs easier for us:
     If you feel the source code should be reformatted, create a separate PR for this change.
   - Check for unnecessary whitespace with `git diff --check` before committing.
 - Make sure you have added the necessary tests (JUnit/IT) for your changes.
-- Run all the tests with `mvn -Prun-its verify` to assure nothing else was accidentally broken.
+- Run all the tests with `mvn clean verify` to assure nothing else was accidentally broken.
 - Submit a pull request to the repository in this organization.
 
 ### Additional Resources

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>8</javaVersion>
+    <javaVersion>17</javaVersion>
     <mavenVersion>3.9.9</mavenVersion>
     <!-- Maven bound -->
     <resolverVersion>1.9.22</resolverVersion>
@@ -94,6 +94,16 @@ under the License.
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>land.oras</groupId>
+      <artifactId>oras-java-sdk</artifactId>
+      <version>0.2.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.28.0</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
@@ -208,6 +218,12 @@ under the License.
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
       <version>${slf4jVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.21.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/land/oras/utils/ZotContainer.java
+++ b/src/test/java/land/oras/utils/ZotContainer.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package land.oras.utils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+
+@NullMarked
+public class ZotContainer extends GenericContainer<ZotContainer> {
+
+    /**
+     * Logger
+     */
+    private Logger LOG = LoggerFactory.getLogger(ZotContainer.class);
+
+    // myuser:mypass
+    public static final String AUTH_STRING = "myuser:$2y$05$M1VYs6EzFkXBmuS.BrIreObAnJcWCgzSPeT9/Rh3aVEqTqtSL8XN.";
+    public static final int ZOT_PORT = 5000;
+
+    /**
+     * Create a new registry container
+     */
+    public ZotContainer() {
+        super("ghcr.io/project-zot/zot-linux-amd64:v2.1.8");
+        addExposedPort(ZOT_PORT);
+        setWaitStrategy(Wait.forHttp("/v2/_catalog").forPort(ZOT_PORT).forStatusCode(401));
+
+        try {
+            // Auth file
+            Path authFile = Files.createTempFile("auth", ".htpasswd");
+            Files.writeString(authFile, AUTH_STRING);
+
+            // Zot config file
+            Path configFile = Files.createTempFile("zot-config", ".json");
+            // language=JSON
+            String configJson =
+                    """
+                     {
+                       "storage": { "rootDirectory": "/var/lib/registry" },
+                       "http": {
+                         "address": "0.0.0.0",
+                         "port": %s,
+                         "auth": {
+                           "htpasswd": { "path": "/etc/zot/auth.htpasswd" }
+                         }
+                       },
+                       "extensions": {
+                         "search": { "enable": true }
+                       }
+                     }
+               """
+                            .formatted(ZOT_PORT);
+
+            Files.writeString(configFile, configJson);
+
+            // Copy it into the container
+            withCopyFileToContainer(
+                    MountableFile.forHostPath(authFile.toAbsolutePath().toString()), "/etc/zot/auth.htpasswd");
+            withCopyFileToContainer(
+                    MountableFile.forHostPath(configFile.toAbsolutePath().toString()), "/etc/zot/config.json");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create auth.htpasswd", e);
+        }
+    }
+
+    /**
+     * Get the registry URL
+     * @return The registry URL
+     */
+    public String getRegistry() {
+        return getHost() + ":" + getMappedPort(ZOT_PORT);
+    }
+
+    public ZotContainer withFollowOutput() {
+        followOutput(new Slf4jLogConsumer(LOG));
+        return this;
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/deploy/DeployMojoTest.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
+import land.oras.utils.ZotContainer;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -73,6 +74,8 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
     private MavenSession session;
 
+    private ZotContainer zotContainer;
+
     @InjectMocks
     private DeployMojo mojo;
 
@@ -111,6 +114,10 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         if (ociArtifactsRepo.exists()) {
             FileUtils.deleteDirectory(ociArtifactsRepo);
         }
+
+        zotContainer = new ZotContainer();
+        zotContainer.setStartupAttempts(3);
+        zotContainer.start();
     }
 
     public void tearDown() throws Exception {
@@ -122,6 +129,10 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
         if (openMocks != null) {
             openMocks.close();
+        }
+
+        if (zotContainer != null) {
+            zotContainer.stop();
         }
     }
 
@@ -161,6 +172,12 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
+        setVariableValueToObject(
+                mojo, "imageRepo", zotContainer.getRegistry() + "/m2/org/apache/maven/test/maven-deploy-test");
+        setVariableValueToObject(mojo, "imageTag", "1.0-SNAPSHOT");
+        setVariableValueToObject(mojo, "registryUsername", "myuser");
+        setVariableValueToObject(mojo, "registryPassword", "mypass");
+        setVariableValueToObject(mojo, "insecureTLSNoVerify", Boolean.TRUE);
 
         artifact = (DeployArtifactStub) project.getArtifact();
 
@@ -192,11 +209,11 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         expectedFiles.add("test");
         expectedFiles.add("maven-deploy-test");
         expectedFiles.add("1.0-SNAPSHOT");
-        expectedFiles.add("maven-metadata-deploy-test.xml");
+        // expectedFiles.add("maven-metadata-deploy-test.xml");
         // expectedFiles.add( "maven-deploy-test-1.0-SNAPSHOT.jar" );
         // expectedFiles.add( "maven-deploy-test-1.0-SNAPSHOT.pom" );
         // as we are in SNAPSHOT the file is here twice
-        expectedFiles.add("maven-metadata-deploy-test.xml");
+        // expectedFiles.add("maven-metadata-deploy-test.xml");
         // extra Aether files
         expectedFiles.add("resolver-status.properties");
         expectedFiles.add("resolver-status.properties");
@@ -235,9 +252,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         expectedFiles.add("maven-metadata.xml.md5");
         expectedFiles.add("maven-metadata.xml.sha1");
 
-        remoteRepo = new File(remoteRepo, "basic-deploy-test");
+        // remoteRepo = new File(remoteRepo, "basic-deploy-test");
 
-        assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
+        // assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
         assertRepoExpectedFiles(ociArtifactsRepo, "oci-artifacts", expectedFiles);
     }
 
@@ -327,7 +344,12 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-
+        setVariableValueToObject(
+                mojo, "imageRepo", zotContainer.getRegistry() + "/m2/org/apache/maven/test/maven-deploy-test");
+        setVariableValueToObject(mojo, "imageTag", "1.0-SNAPSHOT");
+        setVariableValueToObject(mojo, "registryUsername", "myuser");
+        setVariableValueToObject(mojo, "registryPassword", "mypass");
+        setVariableValueToObject(mojo, "insecureTLSNoVerify", Boolean.TRUE);
         artifact = (DeployArtifactStub) project.getArtifact();
 
         artifact.setArtifactHandlerExtension(project.getPackaging());
@@ -358,9 +380,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         expectedFiles.add("maven-metadata.xml");
         expectedFiles.add("maven-metadata.xml.md5");
         expectedFiles.add("maven-metadata.xml.sha1");
-        remoteRepo = new File(remoteRepo, "basic-deploy-pom");
+        // remoteRepo = new File(remoteRepo, "basic-deploy-pom");
 
-        assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
+        // assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
         assertRepoExpectedFiles(ociArtifactsRepo, "oci-artifacts", expectedFiles);
     }
 
@@ -392,7 +414,12 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-
+        setVariableValueToObject(
+                mojo, "imageRepo", zotContainer.getRegistry() + "/m2/org/apache/maven/test/maven-deploy-test");
+        setVariableValueToObject(mojo, "imageTag", "1.0-SNAPSHOT");
+        setVariableValueToObject(mojo, "registryUsername", "myuser");
+        setVariableValueToObject(mojo, "registryPassword", "mypass");
+        setVariableValueToObject(mojo, "insecureTLSNoVerify", Boolean.TRUE);
         artifact = (DeployArtifactStub) project.getArtifact();
 
         artifact.setArtifactHandlerExtension(project.getPackaging());
@@ -423,9 +450,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         expectedFiles.add("maven-metadata.xml");
         expectedFiles.add("maven-metadata.xml.md5");
         expectedFiles.add("maven-metadata.xml.sha1");
-        remoteRepo = new File(remoteRepo, "basic-deploy-bom");
+        // remoteRepo = new File(remoteRepo, "basic-deploy-bom");
 
-        assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
+        // assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
         assertRepoExpectedFiles(ociArtifactsRepo, "oci-artifacts", expectedFiles);
     }
 
@@ -519,7 +546,12 @@ public class DeployMojoTest extends AbstractMojoTestCase {
 
         setVariableValueToObject(mojo, "pluginContext", new ConcurrentHashMap<>());
         setVariableValueToObject(mojo, "reactorProjects", Collections.singletonList(project));
-
+        setVariableValueToObject(
+                mojo, "imageRepo", zotContainer.getRegistry() + "/m2/org/apache/maven/test/maven-deploy-test");
+        setVariableValueToObject(mojo, "imageTag", "1.0-SNAPSHOT");
+        setVariableValueToObject(mojo, "registryUsername", "myuser");
+        setVariableValueToObject(mojo, "registryPassword", "mypass");
+        setVariableValueToObject(mojo, "insecureTLSNoVerify", Boolean.TRUE);
         artifact = (DeployArtifactStub) project.getArtifact();
 
         File file = new File(
@@ -570,9 +602,9 @@ public class DeployMojoTest extends AbstractMojoTestCase {
         expectedFiles.add("maven-metadata.xml.md5");
         expectedFiles.add("maven-metadata.xml.sha1");
 
-        remoteRepo = new File(remoteRepo, "basic-deploy-with-attached-artifacts");
+        // remoteRepo = new File(remoteRepo, "basic-deploy-with-attached-artifacts");
 
-        assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
+        // assertRepoExpectedFiles(remoteRepo, "remote", expectedFiles);
         assertRepoExpectedFiles(ociArtifactsRepo, "oci-artifacts", expectedFiles);
     }
 


### PR DESCRIPTION
Deploy commands now upload the Maven content to a container registry. This takes advantage of the `oras-java-sdk` library, currently under active development (alpha).

Utility code from the oras-java-sdk project was copied to facilitate testing. Ideally this is provided as a separate library that can be imported with the test scope. The utilities leverage testcontainers, which are best lifecycled with JUnit. A separate refactor effort is needed to convert the integration tests to run with JUnit. Existing logic to deploy Maven artifacts to configured remote repos was removed.

The following breaking changes were introduced:

- Upgrade compiled JDK to 17 - remove JDK 8 from test matrix.
- Disable the integration tests for the interim, as any testing will need a running container registry (provided by Testcontainers).
- Reduce CI matrix to just `ubuntu-latest`, to avoid challenges with GH Actions and Testcontainers.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body. 
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
